### PR TITLE
Danger verbose fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.1)
+    addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     claide (1.0.1)
     claide-plugins (0.9.2)
@@ -16,13 +16,12 @@ GEM
       open4 (~> 1.3)
     coderay (1.1.1)
     colored (1.2)
-    colored2 (3.1.2)
     cork (0.2.0)
       colored (~> 1.2)
-    danger (4.3.2)
+    danger (4.0.1)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
-      colored2 (~> 3.1)
+      colored (~> 1.2)
       cork (~> 0.1)
       faraday (~> 0.9)
       faraday-http-cache (~> 1.0)
@@ -33,7 +32,7 @@ GEM
     danger-plugin-api (1.0.0)
       danger (> 2.0)
     diff-lcs (1.2.5)
-    faraday (0.12.0.1)
+    faraday (0.10.0)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
@@ -54,7 +53,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    kramdown (1.13.2)
+    kramdown (1.13.1)
     listen (3.0.7)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
@@ -73,7 +72,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    public_suffix (2.0.5)
+    public_suffix (2.0.4)
     rake (10.5.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
@@ -99,7 +98,7 @@ GEM
     terminal-table (1.7.3)
       unicode-display_width (~> 1.1.1)
     thor (0.19.4)
-    unicode-display_width (1.1.3)
+    unicode-display_width (1.1.1)
     yard (0.9.5)
 
 PLATFORMS
@@ -117,4 +116,4 @@ DEPENDENCIES
   yard (~> 0.8)
 
 BUNDLED WITH
-   1.14.5
+   1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    danger-xcodebuild (0.0.6)
+    danger-xcodebuild (0.0.7)
       danger-plugin-api (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.0)
+    addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     claide (1.0.1)
     claide-plugins (0.9.2)
@@ -16,12 +16,13 @@ GEM
       open4 (~> 1.3)
     coderay (1.1.1)
     colored (1.2)
+    colored2 (3.1.2)
     cork (0.2.0)
       colored (~> 1.2)
-    danger (4.0.1)
+    danger (4.3.2)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
-      colored (~> 1.2)
+      colored2 (~> 3.1)
       cork (~> 0.1)
       faraday (~> 0.9)
       faraday-http-cache (~> 1.0)
@@ -32,7 +33,7 @@ GEM
     danger-plugin-api (1.0.0)
       danger (> 2.0)
     diff-lcs (1.2.5)
-    faraday (0.10.0)
+    faraday (0.12.0.1)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
@@ -53,7 +54,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    kramdown (1.13.1)
+    kramdown (1.13.2)
     listen (3.0.7)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
@@ -72,7 +73,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    public_suffix (2.0.4)
+    public_suffix (2.0.5)
     rake (10.5.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
@@ -98,7 +99,7 @@ GEM
     terminal-table (1.7.3)
       unicode-display_width (~> 1.1.1)
     thor (0.19.4)
-    unicode-display_width (1.1.1)
+    unicode-display_width (1.1.3)
     yard (0.9.5)
 
 PLATFORMS
@@ -116,4 +117,4 @@ DEPENDENCIES
   yard (~> 0.8)
 
 BUNDLED WITH
-   1.12.5
+   1.14.5

--- a/lib/xcodebuild/gem_version.rb
+++ b/lib/xcodebuild/gem_version.rb
@@ -1,3 +1,3 @@
 module Xcodebuild
-  VERSION = "0.0.6".freeze
+  VERSION = "0.0.7".freeze
 end

--- a/lib/xcodebuild/plugin.rb
+++ b/lib/xcodebuild/plugin.rb
@@ -49,6 +49,8 @@ module Danger
     # @return   [warning_count]
     #
     def parse_warnings
+      return unless @xcodebuild_json
+
       @warning_count = @xcodebuild_json["warnings"].count
       @warning_count = @warning_count + @xcodebuild_json["ld_warnings"].count
       @warning_count = @warning_count + @xcodebuild_json["compile_warnings"].count
@@ -66,6 +68,8 @@ module Danger
     # @return   [error_count]
     #
     def parse_errors
+      return unless @xcodebuild_json
+
       errors = @xcodebuild_json["errors"].map {|x| "`#{x}`"}
       errors += @xcodebuild_json["compile_errors"].map {|x| "`[#{x["file_path"].split("/").last}] #{x["reason"]}`"}
       errors += @xcodebuild_json["file_missing_errors"].map {|x| "`[#{x["file_path"].split("/").last}] #{x["reason"]}`"}
@@ -89,6 +93,8 @@ module Danger
     # @return   [test_failures]
     #
     def parse_tests
+      return unless @xcodebuild_json
+
       test_failures = Array.new
       @xcodebuild_json["tests_failures"].each do |key, value|
         test_failures += value.map {|x| "`[#{x["file_path"].split("/").last}] [#{x["test_case"]}] #{x["reason"]}`"}
@@ -112,18 +118,20 @@ module Danger
     # @return   [is_perfect_build]
     #
     def perfect_build
+      return unless @xcodebuild_json
+
       is_perfect_build = @warning_count == 0 && @error_count == 0 && @test_failures_count == 0
       if post_messages
-          message = Array.new
-          message.push (@build_title) unless @build_title.nil?
-          message.push ("Perfect build 👍🏻")
-          message(message.reject(&:empty?).join(" ")) if is_perfect_build
+        message = Array.new
+        message.push (@build_title) unless @build_title.nil?
+        message.push ("Perfect build 👍🏻")
+        message(message.reject(&:empty?).join(" ")) if is_perfect_build
       end
       return is_perfect_build
     end
 
     def self.instance_name
-          to_s.gsub("Danger", "").danger_underscore.split("/").last
+      to_s.gsub("Danger", "").danger_underscore.split("/").last
     end
   end
 end


### PR DESCRIPTION
When running danger local or danger pr the --verbose flag is added.  This causes all methods to get called and danger-xcodebuild crashes anytime `@xcodebuild_json` is accessed since it is nil.

I added return unless @xcodebuild_json to prevent the crash. 
